### PR TITLE
salt-master: mitigate impact of meltdown patches

### DIFF
--- a/kubic-salt-master-image/root/usr/local/bin/entrypoint.sh
+++ b/kubic-salt-master-image/root/usr/local/bin/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+NOFILE_LIMIT=${NOFILE_LIMIT:-20000}
+
 if [ -z "$SALTAPI_PASSWORD" ] && [ -z "$SALTAPI_PASSWORD_FILE" ]; then
   echo >&2 "You need to provide SALTAPI_PASSWORD or SALTAPI_PASSWORD_FILE"
   exit 1
@@ -10,5 +12,8 @@ if [ -n "$SALTAPI_PASSWORD_FILE" ] && [ -f "$SALTAPI_PASSWORD_FILE" ]; then
 fi
 
 echo "saltapi:$SALTAPI_PASSWORD" | chpasswd
+
+# Set lower number of max open fd per process. Required to fix bsc#1074836
+ulimit -n ${NOFILE_LIMIT}
 
 exec "$@"


### PR DESCRIPTION
salt-master starts quite some external programs at boot time to collect facts about the machine where it's running. Each external call leads python2 to issue a lot of close()s syscalls. The majority of these calls are issued against file descriptors that are invalid (they have never been opened). That leads to the creation of errored close()s, which are NULL syscalls. These NULL syscalls are particularly affected by the meltdown fixes.

This leads to situations where the 1st salt-master worker takes around 2 minutes to be ready to handle incoming requests.

With this patch we can limit the maximum number of file descriptors open per process. This limit the range over which python2 will issue the close()s calls, leading to less NULL syscalls.

With this patch in place the 1st salt-master worker is ready in ~12 seconds.

Fixes bsc#1074836