### PR TITLE
Change tag by %%TAG%% place holder

### DIFF
--- a/kubic-caasp-dex-image/kubic-caasp-dex-image.kiwi
+++ b/kubic-caasp-dex-image/kubic-caasp-dex-image.kiwi
@@ -12,7 +12,7 @@
       derived_from="obsrepositories:/opensuse/tumbleweed#current">
       <containerconfig
         name="kubic/caasp-dex"
-        tag="2.7.1"
+        tag="%%TAG%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/bin/caasp-dex"/>
         <subcommand execute="version">

--- a/kubic-chartmuseum-image/kubic-chartmuseum-image.kiwi
+++ b/kubic-chartmuseum-image/kubic-chartmuseum-image.kiwi
@@ -12,7 +12,7 @@
       derived_from="obsrepositories:/opensuse/tumbleweed#current">
       <containerconfig
         name="kubic/chartmuseum"
-        tag="0.2.1"
+        tag="%%TAG%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/bin/chartmuseum"/>
       </containerconfig>

--- a/kubic-dnsmasq-nanny-image/kubic-dnsmasq-nanny-image.kiwi
+++ b/kubic-dnsmasq-nanny-image/kubic-dnsmasq-nanny-image.kiwi
@@ -12,7 +12,7 @@
       derived_from="obsrepositories:/opensuse/tumbleweed#current">
       <containerconfig
         name="kubic/dnsmasq-nanny"
-        tag="1.0.0"
+        tag="%%TAG%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/bin/dnsmasq-nanny"/>
       </containerconfig>

--- a/kubic-flannel-image/kubic-flannel-image.kiwi
+++ b/kubic-flannel-image/kubic-flannel-image.kiwi
@@ -12,7 +12,7 @@
       derived_from="obsrepositories:/opensuse/tumbleweed#current">
       <containerconfig
         name="kubic/flannel"
-        tag="0.9.1"
+        tag="%%TAG%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/sbin/flanneld"/>
       </containerconfig>

--- a/kubic-haproxy-image/kubic-haproxy-image.kiwi
+++ b/kubic-haproxy-image/kubic-haproxy-image.kiwi
@@ -12,7 +12,7 @@
       derived_from="obsrepositories:/opensuse/tumbleweed#current">
       <containerconfig
         name="kubic/haproxy"
-        tag="1.6.0"
+        tag="%%TAG%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <expose>
           <port number="80"/>

--- a/kubic-helm-tiller-image/kubic-helm-tiller-image.kiwi
+++ b/kubic-helm-tiller-image/kubic-helm-tiller-image.kiwi
@@ -12,7 +12,7 @@
       derived_from="obsrepositories:/opensuse/tumbleweed#current">
       <containerconfig
         name="kubic/tiller"
-        tag="2.7.2"
+        tag="%%TAG%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/bin/tiller"/>
       </containerconfig>

--- a/kubic-kube-dns-image/kubic-kube-dns-image.kiwi
+++ b/kubic-kube-dns-image/kubic-kube-dns-image.kiwi
@@ -12,7 +12,7 @@
       derived_from="obsrepositories:/opensuse/tumbleweed#current">
       <containerconfig
         name="kubic/kubedns"
-        tag="1.0.0"
+        tag="%%TAG%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/bin/kube-dns"/>
       </containerconfig>

--- a/kubic-kube-dns-sidecar-image/kubic-kube-dns-sidecar-image.kiwi
+++ b/kubic-kube-dns-sidecar-image/kubic-kube-dns-sidecar-image.kiwi
@@ -12,7 +12,7 @@
       derived_from="obsrepositories:/opensuse/tumbleweed#current">
       <containerconfig
         name="kubic/sidecar"
-        tag="1.0.0"
+        tag="%%TAG%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/bin/sidecar"/>
       </containerconfig>

--- a/kubic-kubernetes-node-pause-image/kubic-kubernetes-node-pause-image.kiwi
+++ b/kubic-kubernetes-node-pause-image/kubic-kubernetes-node-pause-image.kiwi
@@ -12,7 +12,7 @@
       derived_from="obsrepositories:/opensuse/tumbleweed#current">
       <containerconfig
         name="kubic/pause"
-        tag="1.0.0"
+        tag="%%TAG%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <subcommand execute="/usr/share/suse-docker-images/pause/pause"/>
       </containerconfig>

--- a/kubic-mariadb-image/kubic-mariadb-image.kiwi
+++ b/kubic-mariadb-image/kubic-mariadb-image.kiwi
@@ -12,7 +12,7 @@
       derived_from="obsrepositories:/opensuse/tumbleweed#current">
       <containerconfig
         name="kubic/mariadb"
-        tag="10.0"
+        tag="%%TAG%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <expose>
           <port number="3306"/>

--- a/kubic-openldap-image/kubic-openldap-image.kiwi
+++ b/kubic-openldap-image/kubic-openldap-image.kiwi
@@ -12,7 +12,7 @@
       derived_from="obsrepositories:/opensuse/tumbleweed#current">
       <containerconfig
         name="kubic/openldap"
-        tag="10.0"
+        tag="%%TAG%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <expose>
           <port number="389"/>

--- a/kubic-pv-recycler-node-image/kubic-pv-recycler-node-image.kiwi
+++ b/kubic-pv-recycler-node-image/kubic-pv-recycler-node-image.kiwi
@@ -12,7 +12,7 @@
       derived_from="obsrepositories:/opensuse/tumbleweed#current">
       <containerconfig
         name="kubic/pv-recycler-node"
-        tag="1.0.0"
+        tag="%%TAG%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
       </containerconfig> 
     </type>

--- a/kubic-salt-api-image/kubic-salt-api-image.kiwi
+++ b/kubic-salt-api-image/kubic-salt-api-image.kiwi
@@ -12,7 +12,7 @@
       derived_from="obsrepositories:/opensuse/tumbleweed#current">
       <containerconfig
         name="kubic/salt-api"
-        tag="2016.11.4"
+        tag="%%TAG%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <subcommand execute="salt-api"/>
       </containerconfig> 

--- a/kubic-salt-master-image/kubic-salt-master-image.kiwi
+++ b/kubic-salt-master-image/kubic-salt-master-image.kiwi
@@ -12,7 +12,7 @@
       derived_from="obsrepositories:/opensuse/tumbleweed#current">
       <containerconfig
         name="kubic/salt-master"
-        tag="2016.11.4"
+        tag="%%TAG%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="entrypoint.sh"/>
         <subcommand execute="salt-master"/>

--- a/kubic-salt-minion-image/kubic-salt-minion-image.kiwi
+++ b/kubic-salt-minion-image/kubic-salt-minion-image.kiwi
@@ -12,7 +12,7 @@
       derived_from="obsrepositories:/opensuse/tumbleweed#current">
       <containerconfig
         name="kubic/salt-minion"
-        tag="2016.11.4"
+        tag="%%TAG%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <subcommand execute="salt-minion.sh"/>
       </containerconfig> 

--- a/kubic-velum-development-image/kubic-velum-development-image.kiwi
+++ b/kubic-velum-development-image/kubic-velum-development-image.kiwi
@@ -12,7 +12,7 @@
       derived_from="obsrepositories:/opensuse/tumbleweed#current">
       <containerconfig
         name="kubic/velum-development"
-        tag="0.0"
+        tag="%%TAG%%"
         workingdir="/srv/velum"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <expose>

--- a/kubic-velum-image/kubic-velum-image.kiwi
+++ b/kubic-velum-image/kubic-velum-image.kiwi
@@ -12,7 +12,7 @@
       derived_from="obsrepositories:/opensuse/tumbleweed#current">
       <containerconfig
         name="kubic/velum"
-        tag="0.0"
+        tag="%%TAG%%"
         workingdir="/srv/velum"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <expose>


### PR DESCRIPTION
Changing tag by a placeholder facilitates the usage of
replace_using_package_version obs service in buildtime mode so
before every build the %%TAG%% placeholder is replaced by a given
package version. This is handy in order to align the tag of an appliance
to its main application version.