### PR TITLE
[WIP] ingress-controller: Load necessary modules

### DIFF
--- a/kubic-nginx-ingress-controller-image/root/etc/nginx/template/nginx.tmpl
+++ b/kubic-nginx-ingress-controller-image/root/etc/nginx/template/nginx.tmpl
@@ -8,8 +8,10 @@
 {{ $addHeaders := .AddHeaders }}
 
 {{ if $cfg.EnableModsecurity }}
-load_module /etc/nginx/modules/ngx_http_modsecurity_module.so;
+load_module "/usr/lib64/nginx/modules/ngx_http_modsecurity_module.so";
 {{ end }}
+load_module "/usr/lib64/nginx/modules/ngx_http_geoip_module.so";
+load_module "/usr/lib64/nginx/modules/ngx_stream_module.so";
 
 {{ buildOpentracingLoad $cfg }}
 


### PR DESCRIPTION
Nginx needs to load modsecurity, geoip and stream modules.