### PR TITLE
move heapster-image to kubic/caasp template

### DIFF
--- a/heapster-image/heapster-image.kiwi.ini
+++ b/heapster-image/heapster-image.kiwi.ini
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="6.5" name="_PRODUCT_-heapster">
+  <description type="system">
+    <author>SUSE Containers Team</author>
+    <contact>containers@suse.com</contact>
+    <specification>Heapster running on a _DISTRO_ container guest</specification>
+  </description>
+  <preferences>
+    <type 
+      image="docker" 
+      derived_from="obsrepositories:/_BASEIMAGE_">
+      <containerconfig 
+        name="_PRODUCT_/heapster" 
+        tag="%%TAG%%" 
+        maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
+        <entrypoint execute="/usr/bin/metrics"/>
+      </containerconfig>
+    </type>
+    <version>1.0.1</version>
+    <packagemanager>zypper</packagemanager>
+    <rpm-check-signatures>false</rpm-check-signatures>
+    <rpm-force>true</rpm-force>
+    <rpm-excludedocs>true</rpm-excludedocs>
+    <locale>en_US</locale>
+    <keytable>us.map.gz</keytable>
+    <hwclock>utc</hwclock>
+  </preferences>
+  <repository>
+      <source path="obsrepositories:/"/>
+  </repository>
+  <packages type="image">
+      <package name="heapster"/>
+  </packages>
+</image>


### PR DESCRIPTION
Move here so this can get into V4 (prerequisite to k8s dashboard)
- update author to SUSE containers team
- remove nobody user/group
- bump version