### PR TITLE
Use correct image name and tag for SLE15 base image

### DIFF
--- a/pre_checkin.sh
+++ b/pre_checkin.sh
@@ -8,7 +8,7 @@ for product in kubic caasp; do
             baseimage="opensuse/tumbleweed#current"
             distro="openSUSE Kubic"
         else
-            baseimage="suse/sles15#current"
+            baseimage="suse/sle15#current"
             distro="SLES15"
         fi
         sed -i -e "s@_BASEIMAGE_@${baseimage}@g" \


### PR DESCRIPTION
With this commit the base image is set to suse/sle15:current for
caasp images, in line with SUSE:SLE-15:GA/sles15-image and bsc#1083671