### PR TITLE
Force the right configuration file for slapd

### DIFF
--- a/openldap-image/openldap-image.kiwi.ini
+++ b/openldap-image/openldap-image.kiwi.ini
@@ -16,17 +16,19 @@
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <expose>
           <port number="389"/>
-          <port number="636"/> 
+          <port number="636"/>
         </expose>
         <volumes>
           <volume name="/var/lib/ldap"/>
         </volumes>
         <entrypoint execute="/usr/local/bin/entrypoint.sh"/>
         <subcommand execute="/usr/sbin/slapd">
+          <argument name="-f"/>
+          <argument name="/etc/openldap/slapd.conf"/>
           <argument name="-d"/>
-          <argument name="32768"/>	  
+          <argument name="32768"/>
         </subcommand>
-      </containerconfig> 
+      </containerconfig>
     </type>
     <version>4.0.1</version>
     <packagemanager>zypper</packagemanager>
@@ -43,5 +45,5 @@
   <packages type="image">
     <package name="openldap2"/>
     <package name="openldap2-client"/>
-  </packages> 
+  </packages>
 </image>


### PR DESCRIPTION
For some unknown reason, `/etc/openldap/slapd.conf` was not being loaded by `slapd`. This forces the right configuration file for `slapd`.

https://bugzilla.suse.com/show_bug.cgi?id=1092495

bsc#1092495