### PR TITLE
Allow providing configuration settings using envvars

### DIFF
--- a/mariadb-image/mariadb-image.kiwi.ini
+++ b/mariadb-image/mariadb-image.kiwi.ini
@@ -27,8 +27,9 @@
         </subcommand>
         <environment>
             <env name="MYSQL_DISABLE_REMOTE_ROOT" value="true"/>
+            <env name="MYSQLD_CONFIG" value=""/>
         </environment>
-      </containerconfig> 
+      </containerconfig>
     </type>
     <version>4.0.1</version>
     <packagemanager>zypper</packagemanager>
@@ -44,5 +45,5 @@
   </repository>
   <packages type="image">
     <package name="mariadb"/>
-  </packages> 
+  </packages>
 </image>


### PR DESCRIPTION
With the envvar `MYSQLD_CONFIG` it's possible to set default mysqld
settings that will be written into `/etc/my.cnf.d` when the container
starts.

E.g. `MYSQLD_CONFIG="skip-networking;max_allowed_packet=16M"` will produce:

```
[mysqld]
skip-networking
max_allowed_packet=16M
```

Fixes: bsc#1095335