### PR TITLE
openldap-image: fix path of slapd in entrypoint.sh

### DIFF
--- a/openldap-image/root/usr/local/bin/entrypoint.sh
+++ b/openldap-image/root/usr/local/bin/entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 set -o pipefail
 
 # The sladp executable
-EXE="/usr/lib/openldap/slapd"
+EXE="/usr/sbin/slapd"
 
 # Directory where slapd configuration will be stored
 # Will be persistent (mounted from the host)


### PR DESCRIPTION
entrypoint.sh used the old path of slapd