### PR TITLE
nginx-ingress: Add nginx modules

### DIFF
--- a/nginx-ingress-controller-image/nginx-ingress-controller-image.kiwi.ini
+++ b/nginx-ingress-controller-image/nginx-ingress-controller-image.kiwi.ini
@@ -35,5 +35,14 @@
     <package name="nginx-geolite-city"/>
     <package name="nginx-geolite-asn"/>
     <package name="nginx-ingress-controller"/>
+    <package name="nginx-module-brotli"/>
+    <package name="nginx-module-cookie-flag"/>
+    <package name="nginx-module-devel-kit"/>
+    <package name="nginx-module-http-auth-digest"/>
+    <package name="nginx-module-http-substitutions-filter"/>
+    <package name="nginx-module-modsecurity"/>
+    <package name="nginx-module-set-misc"/>
+    <package name="nginx-module-sticky-ng"/>
+    <package name="nginx-module-vts"/>
   </packages>
 </image>


### PR DESCRIPTION
Nginx modules are shipped in separate packages in openSUSE Factory
and this change provides the following:

- nginx-module-brotli
- nginx-module-cookie-flag
- nginx-module-devel-kit
- nginx-module-http-auth-digest
- nginx-module-http-substitutions-filter
- nginx-module-modsecurity
- nginx-module-set-misc
- nginx-module-sticky-ng
- nginx-module-vts