### PR TITLE
default-http-backend: Fix binary name

### DIFF
--- a/default-http-backend-image/default-http-backend-image.kiwi.ini
+++ b/default-http-backend-image/default-http-backend-image.kiwi.ini
@@ -14,7 +14,7 @@
         name="_PRODUCT_/default-http-backend"
         tag="%%TAG%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
-        <entrypoint execute="/usr/bin/default-http-backend"/>
+        <entrypoint execute="/usr/bin/kubernetes-404-server"/>
       </containerconfig>
     </type>
     <version>4.0.1</version>


### PR DESCRIPTION
The binary of default HTTP backend is called kubernetes-404-server,
not default-http-backend.