### PR TITLE
 Add additional tags for images

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,18 @@ image tag consistent over time there is an automation procedure in place for
 the builds within the Open Build Service. The `replace_using_package_version`
 service serves that purpose and should be used in the following way:
 
-1. Include a placeholder in the kiwi description file as the tag value.
+1. Include an arbitrary placeholder in the kiwi description file as the
+tag value.
 2. In OBS set the `replace_using_package_version` service to replace the
 placeholder. 
 
 Consider the following example for a mariadb image:
 
-1. In `kubic-mariadb-image.kiwi` use the `%%TAG%%` placeholder:
+1. In `kubic-mariadb-image.kiwi` use the `%%VERSION%%` placeholder:
 
 ```xml
 (...)
-<containerconfig name="kubic/mariadb" tag="%%TAG%%"/>
+<containerconfig name="kubic/mariadb" tag="%%VERSION%%"/>
 (...)
 ```
 
@@ -39,12 +40,71 @@ Consider the following example for a mariadb image:
 ```xml
 <service name="replace_using_package_version" mode="buildtime">
     <param name="file">kubic-mariadb-image.kiwi</param>
-    <param name="regex">%%TAG%%</param>
+    <param name="regex">%%VERSION%%</param>
+    <param name="parse-version">minor</param>
     <param name="package">mariadb</param>
 </service>
-    
 ```
 
 This configuration will set the tag to the mariadb package version at build
 time. This specially handy for images based on rolling releases like
 Tumbleweed, where the application versions might change at anytime.
+
+The `parse-version` optional parameter is used to simplify the version string.
+It can take `major`, `minor` and `patch` values. `patch` will use a version
+style like `MAJOR.MINOR.PATCH` (three decimal numbers separated by dots),
+`minor` something like `MAJOR.MINOR` and `major` will just use the first
+decimal number. If not present the full version string is used.
+
+### Additional tags
+
+Additional tags are appended in to the registry by using the following
+OBS specific syntax:
+
+```xml
+<!-- OBS-AddTag: name1:tag1 name2:tag2 -->
+```
+
+If tag includes the `<RELEASE>` marker this is replaced by the release number,
+which is different for every build. Thus using something like:
+
+```xml
+<!-- OBS-AddTag: kubic/mariadb:%%VERSION%%-<RELEASE> -->
+```
+
+Would produce an image reference like `kubic/mariadb:10.2-5.1` where `10.2`
+stands for `MAJOR.MINOR` version of mariadb package and `5.1` stands for
+revision 5 build 1. This is an additional reference to what is defined within
+the kiwi description file.
+
+The `replace_using_package_version` can be called multiple times in `_service`
+file, so tagging an image with multiple tags based on different version
+levels is also possible.
+
+Consider the kiwi file has:
+
+```xml
+<!-- OBS-AddTag: kubic/mariadb:%%SHORT_VERSION%% kubic/mariadb:%%LONG_VERSION%%-<RELEASE> -->
+```
+
+and `_service` file has:
+
+```xml
+<service name="replace_using_package_version" mode="buildtime">
+    <param name="file">kubic-mariadb-image.kiwi</param>
+    <param name="regex">%%SHORT_VERSION%%</param>
+    <param name="parse-version">major</param>
+    <param name="package">mariadb</param>
+</service>
+<service name="replace_using_package_version" mode="buildtime">
+    <param name="file">kubic-mariadb-image.kiwi</param>
+    <param name="regex">%%LONG_VERSION%%</param>
+    <param name="parse-version">patch</param>
+    <param name="package">mariadb</param>
+</service>
+```
+For this specific case the tags would be expanded to something like 
+`kubic/mariadb:10` and `kubic/mariadb:10.2.3-6.2`.
+
+Note `OBS-AddTag` is only applied to published images when published to the
+registry, this has no effect on the resulting binary.

--- a/caasp-dex-image/caasp-dex-image.kiwi.ini
+++ b/caasp-dex-image/caasp-dex-image.kiwi.ini
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+<!-- OBS-AddTag: _PRODUCT_/caasp-dex:%%LONG_VERSION%% _PRODUCT_/caasp-dex:%%LONG_VERSION%%-<RELEASE> -->
+
 <image schemaversion="6.5" name="_PRODUCT_-caasp-dex">
   <description type="system">
     <author>SUSE Containers Team</author>
@@ -12,7 +14,7 @@
       derived_from="obsrepositories:/_BASEIMAGE_">
       <containerconfig
         name="_PRODUCT_/caasp-dex"
-        tag="%%TAG%%"
+        tag="%%SHORT_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/bin/caasp-dex"/>
         <subcommand execute="version">

--- a/chartmuseum-image/chartmuseum-image.kiwi.ini
+++ b/chartmuseum-image/chartmuseum-image.kiwi.ini
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+<!-- OBS-AddTag: _PRODUCT_/chartmuseum:%%LONG_VERSION%% _PRODUCT_/chartmuseum:%%LONG_VERSION%%-<RELEASE> -->
+
 <image schemaversion="6.5" name="_PRODUCT_-chartmuseum">
   <description type="system">
     <author>SUSE Containers Team</author>
@@ -12,7 +14,7 @@
       derived_from="obsrepositories:/_BASEIMAGE_">
       <containerconfig
         name="_PRODUCT_/chartmuseum"
-        tag="%%TAG%%"
+        tag="%%SHORT_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/bin/chartmuseum"/>
       </containerconfig>

--- a/cilium-image/cilium-image.kiwi.ini
+++ b/cilium-image/cilium-image.kiwi.ini
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+<!-- OBS-AddTag: _PRODUCT_/cilium:%%LONG_VERSION%% _PRODUCT_/cilium:%%LONG_VERSION%%-<RELEASE> -->
+
 <image schemaversion="6.5" name="_PRODUCT_-cilium">
   <description type="system">
     <author>SUSE Containers Team</author>
@@ -12,7 +14,7 @@
       derived_from="obsrepositories:/_BASEIMAGE_">
       <containerconfig
         name="_PRODUCT_/cilium"
-        tag="%%TAG%%"
+        tag="%%SHORT_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/bin/cilium-agent"/>
       </containerconfig>

--- a/default-http-backend-image/default-http-backend-image.kiwi.ini
+++ b/default-http-backend-image/default-http-backend-image.kiwi.ini
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+<!-- OBS-AddTag: _PRODUCT_/default-http-backend:%%LONG_VERSION%% _PRODUCT_/default-http-backend:%%LONG_VERSION%%-<RELEASE> -->
+
 <image schemaversion="6.5" name="_PRODUCT_-default-http-backend">
   <description type="system">
     <author>SUSE Containers Team</author>
@@ -12,7 +14,7 @@
       derived_from="obsrepositories:/_BASEIMAGE_">
       <containerconfig
         name="_PRODUCT_/default-http-backend"
-        tag="%%TAG%%"
+        tag="%%SHORT_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/bin/kubernetes-404-server"/>
       </containerconfig>

--- a/dnsmasq-nanny-image/dnsmasq-nanny-image.kiwi.ini
+++ b/dnsmasq-nanny-image/dnsmasq-nanny-image.kiwi.ini
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+<!-- OBS-AddTag: _PRODUCT_/dnsmasq-nanny:%%LONG_VERSION%% _PRODUCT_/dnsmasq-nanny:%%LONG_VERSION%%-<RELEASE> -->
+
 <image schemaversion="6.5" name="_PRODUCT_-dnsmasq-nanny">
   <description type="system">
     <author>SUSE Containers Team</author>
@@ -12,7 +14,7 @@
       derived_from="obsrepositories:/_BASEIMAGE_">
       <containerconfig
         name="_PRODUCT_/dnsmasq-nanny"
-        tag="%%TAG%%"
+        tag="%%SHORT_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/bin/dnsmasq-nanny"/>
       </containerconfig>

--- a/flannel-image/flannel-image.kiwi.ini
+++ b/flannel-image/flannel-image.kiwi.ini
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+<!-- OBS-AddTag: _PRODUCT_/flannel:%%LONG_VERSION%% _PRODUCT_/flannel:%%LONG_VERSION%%-<RELEASE> -->
+
 <image schemaversion="6.5" name="_PRODUCT_-flannel">
   <description type="system">
     <author>SUSE Containers Team</author>
@@ -12,7 +14,7 @@
       derived_from="obsrepositories:/_BASEIMAGE_">
       <containerconfig
         name="_PRODUCT_/flannel"
-        tag="%%TAG%%"
+        tag="%%SHORT_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/sbin/flanneld"/>
       </containerconfig>

--- a/haproxy-image/haproxy-image.kiwi.ini
+++ b/haproxy-image/haproxy-image.kiwi.ini
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+<!-- OBS-AddTag: _PRODUCT_/haproxy:%%LONG_VERSION%% _PRODUCT_/haproxy:%%LONG_VERSION%%-<RELEASE> -->
+
 <image schemaversion="6.5" name="_PRODUCT_-haproxy">
   <description type="system">
     <author>SUSE Containers Team</author>
@@ -12,7 +14,7 @@
       derived_from="obsrepositories:/_BASEIMAGE_">
       <containerconfig
         name="_PRODUCT_/haproxy"
-        tag="%%TAG%%"
+        tag="%%SHORT_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <expose>
           <port number="80"/>

--- a/heapster-image/heapster-image.kiwi.ini
+++ b/heapster-image/heapster-image.kiwi.ini
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+<!-- OBS-AddTag: _PRODUCT_/heapster:%%LONG_VERSION%% _PRODUCT_/heapster:%%LONG_VERSION%%-<RELEASE> -->
+
 <image schemaversion="6.5" name="_PRODUCT_-heapster">
   <description type="system">
     <author>SUSE Containers Team</author>
@@ -12,7 +14,7 @@
       derived_from="obsrepositories:/_BASEIMAGE_">
       <containerconfig 
         name="_PRODUCT_/heapster" 
-        tag="%%TAG%%" 
+        tag="%%SHORT_VERSION%%" 
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/bin/metrics"/>
       </containerconfig>

--- a/helm-tiller-image/helm-tiller-image.kiwi.ini
+++ b/helm-tiller-image/helm-tiller-image.kiwi.ini
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+<!-- OBS-AddTag: _PRODUCT_/tiller:%%LONG_VERSION%% _PRODUCT_/tiller:%%LONG_VERSION%%-<RELEASE> -->
+
 <image schemaversion="6.5" name="_PRODUCT_-helm-tiller">
   <description type="system">
     <author>SUSE Containers Team</author>
@@ -12,7 +14,7 @@
       derived_from="obsrepositories:/_BASEIMAGE_">
       <containerconfig
         name="_PRODUCT_/tiller"
-        tag="%%TAG%%"
+        tag="%%SHORT_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/bin/tiller"/>
       </containerconfig>

--- a/kube-dash-image/kube-dash-image.kiwi.ini
+++ b/kube-dash-image/kube-dash-image.kiwi.ini
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+<!-- OBS-AddTag: _PRODUCT_/kube-dash:%%LONG_VERSION%% _PRODUCT_/kube-dash:%%LONG_VERSION%%-<RELEASE> -->
+
 <image schemaversion="6.5" name="_PRODUCT_-kube-dash">
   <description type="system">
     <author>SUSE Containers Team</author>
@@ -12,7 +14,7 @@
       derived_from="obsrepositories:/_BASEIMAGE_">
       <containerconfig 
         name="_PRODUCT_/kube-dash" 
-        tag="%%TAG%%" 
+        tag="%%SHORT_VERSION%%" 
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/bin/kubernetes-dashboard"/>
       </containerconfig>

--- a/kube-dns-image/kube-dns-image.kiwi.ini
+++ b/kube-dns-image/kube-dns-image.kiwi.ini
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+<!-- OBS-AddTag: _PRODUCT_/kubedns:%%LONG_VERSION%% _PRODUCT_/kubedns:%%LONG_VERSION%%-<RELEASE> -->
+
 <image schemaversion="6.5" name="_PRODUCT_-kubedns">
   <description type="system">
     <author>SUSE Containers Team</author>
@@ -12,7 +14,7 @@
       derived_from="obsrepositories:/_BASEIMAGE_">
       <containerconfig
         name="_PRODUCT_/kubedns"
-        tag="%%TAG%%"
+        tag="%%SHORT_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/bin/kube-dns"/>
       </containerconfig>

--- a/kube-dns-sidecar-image/kube-dns-sidecar-image.kiwi.ini
+++ b/kube-dns-sidecar-image/kube-dns-sidecar-image.kiwi.ini
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+<!-- OBS-AddTag: _PRODUCT_/sidecar:%%LONG_VERSION%% _PRODUCT_/sidecar:%%LONG_VERSION%%-<RELEASE> -->
+
 <image schemaversion="6.5" name="_PRODUCT_-sidecar">
   <description type="system">
     <author>SUSE Containers Team</author>
@@ -12,7 +14,7 @@
       derived_from="obsrepositories:/_BASEIMAGE_">
       <containerconfig
         name="_PRODUCT_/sidecar"
-        tag="%%TAG%%"
+        tag="%%SHORT_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/bin/sidecar"/>
       </containerconfig>

--- a/kubernetes-node-pause-image/kubernetes-node-pause-image.kiwi.ini
+++ b/kubernetes-node-pause-image/kubernetes-node-pause-image.kiwi.ini
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+<!-- OBS-AddTag: _PRODUCT_/pause:%%LONG_VERSION%% _PRODUCT_/pause:%%LONG_VERSION%%-<RELEASE> -->
+
 <image schemaversion="6.5" name="_PRODUCT_-pause">
   <description type="system">
     <author>SUSE Containers Team</author>
@@ -12,7 +14,7 @@
       derived_from="obsrepositories:/_BASEIMAGE_">
       <containerconfig
         name="_PRODUCT_/pause"
-        tag="%%TAG%%"
+        tag="%%SHORT_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <subcommand execute="/usr/share/suse-docker-images/pause/pause"/>
       </containerconfig>

--- a/mariadb-image/mariadb-image.kiwi.ini
+++ b/mariadb-image/mariadb-image.kiwi.ini
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+<!-- OBS-AddTag: _PRODUCT_/mariadb:%%LONG_VERSION%% _PRODUCT_/mariadb:%%LONG_VERSION%%-<RELEASE> -->
+
 <image schemaversion="6.5" name="_PRODUCT_-mariadb">
   <description type="system">
     <author>SUSE Containers Team</author>
@@ -12,7 +14,7 @@
       derived_from="obsrepositories:/_BASEIMAGE_">
       <containerconfig
         name="_PRODUCT_/mariadb"
-        tag="%%TAG%%"
+        tag="%%SHORT_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <expose>
           <port number="3306"/>

--- a/nginx-ingress-controller-image/nginx-ingress-controller-image.kiwi.ini
+++ b/nginx-ingress-controller-image/nginx-ingress-controller-image.kiwi.ini
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+<!-- OBS-AddTag: _PRODUCT_/nginx-ingress-controller:%%LONG_VERSION%% _PRODUCT_/nginx-ingress-controller:%%LONG_VERSION%%-<RELEASE> -->
+
 <image schemaversion="6.5" name="_PRODUCT_-nginx-ingress-controller">
   <description type="system">
     <author>SUSE Containers Team</author>
@@ -12,7 +14,7 @@
       derived_from="obsrepositories:/_BASEIMAGE_">
       <containerconfig
         name="_PRODUCT_/nginx-ingress-controller"
-        tag="%%TAG%%"
+        tag="%%SHORT_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/bin/nginx-ingress-controller"/>
       </containerconfig>

--- a/openldap-image/openldap-image.kiwi.ini
+++ b/openldap-image/openldap-image.kiwi.ini
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+<!-- OBS-AddTag: _PRODUCT_/openldap:%%LONG_VERSION%% _PRODUCT_/openldap:%%LONG_VERSION%%-<RELEASE> -->
+
 <image schemaversion="6.5" name="_PRODUCT_-openldap">
   <description type="system">
     <author>SUSE Containers Team</author>
@@ -12,7 +14,7 @@
       derived_from="obsrepositories:/_BASEIMAGE_">
       <containerconfig
         name="_PRODUCT_/openldap"
-        tag="%%TAG%%"
+        tag="%%SHORT_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <expose>
           <port number="389"/>

--- a/pv-recycler-node-image/pv-recycler-node-image.kiwi.ini
+++ b/pv-recycler-node-image/pv-recycler-node-image.kiwi.ini
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+<!-- OBS-AddTag: _PRODUCT_/pv-recycler-node:%%LONG_VERSION%% _PRODUCT_/pv-recycler-node:%%LONG_VERSION%%-<RELEASE> -->
+
 <image schemaversion="6.5" name="_PRODUCT_-pv-recycler-node">
   <description type="system">
     <author>SUSE Containers Team</author>
@@ -12,7 +14,7 @@
       derived_from="obsrepositories:/_BASEIMAGE_">
       <containerconfig
         name="_PRODUCT_/pv-recycler-node"
-        tag="%%TAG%%"
+        tag="%%SHORT_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
       </containerconfig> 
     </type>

--- a/salt-api-image/salt-api-image.kiwi.ini
+++ b/salt-api-image/salt-api-image.kiwi.ini
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+<!-- OBS-AddTag: _PRODUCT_/salt-api:%%LONG_VERSION%% _PRODUCT_/salt-api:%%LONG_VERSION%%-<RELEASE> -->
+
 <image schemaversion="6.5" name="_PRODUCT_-salt-api">
   <description type="system">
     <author>SUSE Containers Team</author>
@@ -12,7 +14,7 @@
       derived_from="obsrepositories:/_BASEIMAGE_">
       <containerconfig
         name="_PRODUCT_/salt-api"
-        tag="%%TAG%%"
+        tag="%%SHORT_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <subcommand execute="salt-api"/>
       </containerconfig> 

--- a/salt-master-image/salt-master-image.kiwi.ini
+++ b/salt-master-image/salt-master-image.kiwi.ini
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+<!-- OBS-AddTag: _PRODUCT_/salt-master:%%LONG_VERSION%% _PRODUCT_/salt-master:%%LONG_VERSION%%-<RELEASE> -->
+
 <image schemaversion="6.5" name="_PRODUCT_-salt-master">
   <description type="system">
     <author>SUSE Containers Team</author>
@@ -12,7 +14,7 @@
       derived_from="obsrepositories:/_BASEIMAGE_">
       <containerconfig
         name="_PRODUCT_/salt-master"
-        tag="%%TAG%%"
+        tag="%%SHORT_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="entrypoint.sh"/>
         <subcommand execute="salt-master"/>

--- a/salt-minion-image/salt-minion-image.kiwi.ini
+++ b/salt-minion-image/salt-minion-image.kiwi.ini
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+<!-- OBS-AddTag: _PRODUCT_/salt-minion:%%LONG_VERSION%% _PRODUCT_/salt-minion:%%LONG_VERSION%%-<RELEASE> -->
+
 <image schemaversion="6.5" name="_PRODUCT_-salt-minion">
   <description type="system">
     <author>SUSE Containers Team</author>
@@ -12,7 +14,7 @@
       derived_from="obsrepositories:/_BASEIMAGE_">
       <containerconfig
         name="_PRODUCT_/salt-minion"
-        tag="%%TAG%%"
+        tag="%%SHORT_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <subcommand execute="salt-minion.sh"/>
       </containerconfig> 

--- a/velum-development-image/velum-development-image.kiwi.ini
+++ b/velum-development-image/velum-development-image.kiwi.ini
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+<!-- OBS-AddTag: _PRODUCT_/velum-development:%%LONG_VERSION%% _PRODUCT_/velum-development:%%LONG_VERSION%%-<RELEASE> -->
+
 <image schemaversion="6.5" name="_PRODUCT_-velum-development">
   <description type="system">
     <author>SUSE Containers Team</author>
@@ -12,7 +14,7 @@
       derived_from="obsrepositories:/_BASEIMAGE_">
       <containerconfig
         name="_PRODUCT_/velum-development"
-        tag="%%TAG%%"
+        tag="%%SHORT_VERSION%%"
         workingdir="/srv/velum"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <expose>

--- a/velum-image/velum-image.kiwi.ini
+++ b/velum-image/velum-image.kiwi.ini
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+<!-- OBS-AddTag: _PRODUCT_/velum:%%LONG_VERSION%% _PRODUCT_/velum:%%LONG_VERSION%%-<RELEASE> -->
+
 <image schemaversion="6.5" name="_PRODUCT_-velum">
   <description type="system">
     <author>SUSE Containers Team</author>
@@ -12,7 +14,7 @@
       derived_from="obsrepositories:/_BASEIMAGE_">
       <containerconfig
         name="_PRODUCT_/velum"
-        tag="%%TAG%%"
+        tag="%%SHORT_VERSION%%"
         workingdir="/srv/velum"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <expose>


### PR DESCRIPTION
With this commit images will be tagged with three different tags:
```
* <name>:<short_version>
* <name>:<long_version>
* <name>:<long_version>-<release>
```

With change there will be at least a unique tag per build and a semi-stable tag, as the `short_version` is not expected to change within a distro release cycle.