### PR TITLE
Include glibc-devel-32bit only on x86_64

### DIFF
--- a/cilium-image/cilium-image.kiwi.ini
+++ b/cilium-image/cilium-image.kiwi.ini
@@ -38,7 +38,7 @@
     <package name="clang"/>
     <package name="llvm"/>
     <package name="protobuf-c"/>
-    <package name="glibc-devel-32bit"/>
+    <package name="glibc-devel-32bit" arch="x86_64"/>
     <package name="iproute2"/>
     <package name="gcc"/>
     <package name="which"/>


### PR DESCRIPTION
It fixes kubic-cilium-image build for aarch64