### PR TITLE
cilium: add awk in cilium container image

### DIFF
--- a/cilium-image/cilium-image.kiwi.ini
+++ b/cilium-image/cilium-image.kiwi.ini
@@ -42,6 +42,7 @@
     <package name="iproute2"/>
     <package name="gcc"/>
     <package name="which"/>
+    <package name="awk"/>
     <package name="cilium"/>
   </packages>
 </image>


### PR DESCRIPTION
awk is used by cilium's init.sh