### PR TITLE
Add new container dex image for Kubic

### DIFF
--- a/dex-image/dex-image.kiwi.ini
+++ b/dex-image/dex-image.kiwi.ini
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- OBS-AddTag: _NAMESPACE_/dex:%%LONG_VERSION%% _NAMESPACE_/dex:%%LONG_VERSION%%-<RELEASE> -->
+
+<image schemaversion="6.5" name="_PRODUCT_-dex">
+  <description type="system">
+    <author>SUSE Containers Team</author>
+    <contact>containers@suse.com</contact>
+    <specification>Dex running on an _DISTRO_ container guest</specification>
+  </description>
+  <preferences>
+    <type
+      image="docker"
+      derived_from="obsrepositories:/_BASEIMAGE_">
+      <containerconfig
+        name="_NAMESPACE_/dex"
+        tag="%%SHORT_VERSION%%"
+        maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
+        <entrypoint execute="/usr/bin/dex"/>
+        <subcommand execute="version">
+        </subcommand>
+      </containerconfig> 
+    </type>
+    <version>4.0.1</version>
+    <packagemanager>zypper</packagemanager>
+    <rpm-check-signatures>false</rpm-check-signatures>
+    <rpm-force>true</rpm-force>
+    <rpm-excludedocs>true</rpm-excludedocs>
+    <locale>en_US</locale>
+    <keytable>us.map.gz</keytable>
+    <hwclock>utc</hwclock>
+  </preferences>
+  <repository>
+    <source path="obsrepositories:/"/>
+  </repository>
+  <packages type="image">
+    <package name="dex-oidc"/>
+  </packages> 
+</image>
+


### PR DESCRIPTION
This image is going to replace caasp-dex-image. For Kubic and
openSUSE this is already do-able. For SLE15 we need a go1.11 pkg.