### PR TITLE
Rename image files and tags to match other images criteria

### DIFF
--- a/init-image/init-image.kiwi.ini
+++ b/init-image/init-image.kiwi.ini
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: _NAMESPACE_/kubic-init:%%LONG_VERSION%% _NAMESPACE_/kubic-init:%%LONG_VERSION%%-<RELEASE> -->
+<!-- OBS-AddTag: _NAMESPACE_/init:%%LONG_VERSION%% _NAMESPACE_/init:%%LONG_VERSION%%-<RELEASE> -->
 
 <image schemaversion="6.5" name="_PRODUCT_-init">
   <description type="system">
@@ -13,7 +13,7 @@
       image="docker"
       derived_from="obsrepositories:/_BASEIMAGE_">
       <containerconfig
-        name="_NAMESPACE_/_PRODUCT_-init"
+        name="_NAMESPACE_/init"
         tag="%%SHORT_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
       </containerconfig>


### PR DESCRIPTION
This change is to make sure all images follow the same naming criteria.