### PR TITLE
Add coredns image

### DIFF
--- a/coredns-image/coredns-image.kiwi.ini
+++ b/coredns-image/coredns-image.kiwi.ini
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- OBS-AddTag: _NAMESPACE_/coredns:%%LONG_VERSION%% _NAMESPACE_/coredns:%%LONG_VERSION%%-<RELEASE> -->
+
+<image schemaversion="6.5" name="_PRODUCT_-coredns-image">
+  <description type="system">
+    <author>SUSE Containers Team</author>
+    <contact>containers@suse.com</contact>
+    <specification>coredns running on a _DISTRO_ container guest</specification>
+  </description>
+  <preferences>
+    <type
+      image="docker"
+      derived_from="obsrepositories:/_BASEIMAGE_">
+      <containerconfig
+        name="_NAMESPACE_/coredns"
+        tag="%%SHORT_VERSION%%"
+        maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
+        <expose>
+          <port number="53/tcp"/>
+          <port number="53/udp"/>
+        </expose>
+        <entrypoint execute="/usr/sbin/coredns"/>
+        <subcommand clear="true"/>
+      </containerconfig>
+    </type>
+    <version>4.0.1</version>
+    <packagemanager>zypper</packagemanager>
+    <rpm-check-signatures>false</rpm-check-signatures>
+    <rpm-force>true</rpm-force>
+    <rpm-excludedocs>true</rpm-excludedocs>
+    <locale>en_US</locale>
+    <keytable>us.map.gz</keytable>
+    <hwclock>utc</hwclock>
+  </preferences>
+  <repository>
+    <source path="obsrepositories:/"/>
+  </repository>
+  <packages type="image">
+    <package name="coredns"/>
+  </packages>
+</image>


### PR DESCRIPTION
Container image is similar to `k8s.gcr.io/coredns:1.2.6`.

Upstream dockerfile:
```
FROM debian:stable-slim

RUN apt-get update && apt-get -uy upgrade
RUN apt-get -y install ca-certificates && update-ca-certificates

FROM scratch

COPY --from=0 /etc/ssl/certs /etc/ssl/certs
ADD coredns /coredns

EXPOSE 53 53/udp
ENTRYPOINT ["/coredns"
```

Inspecting the image, it exposes both `TCP` and `UDP` port 53:

```
            "ExposedPorts": {
                "53/tcp": {},
                "53/udp": {}
            },
```

__NOTICE__ I hope `kiwi` can do UDP

There's only entrypoint, without CMD

```
            "Entrypoint": [
                "/coredns"
            ],
```