### PR TITLE
Update Tumbleweed base image reference

### DIFF
--- a/pre_checkin.sh
+++ b/pre_checkin.sh
@@ -46,7 +46,7 @@ make_changes_file() {
 
 if [ "${namespace}" == "kubic" ]; then
     product='kubic'
-    baseimage="opensuse/tumbleweed#current"
+    baseimage="opensuse/tumbleweed#latest"
     distro="openSUSE Kubic"
 elif [[ "${namespace}" =~ ^caasp/.* ]]; then
     product='caasp'


### PR DESCRIPTION
Tag of the latest build of Tumbleweed changed from `current` to
`latest`.