### PR TITLE
Add 'v' in front of the tag version

### DIFF
--- a/hyperkube-image/hyperkube-image.kiwi.ini
+++ b/hyperkube-image/hyperkube-image.kiwi.ini
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: _NAMESPACE_/hyperkube:%%LONG_VERSION%% _NAMESPACE_/hyperkube:%%LONG_VERSION%%-<RELEASE> -->
+<!-- OBS-AddTag: _NAMESPACE_/hyperkube:v%%LONG_VERSION%% _NAMESPACE_/hyperkube:v%%LONG_VERSION%%-<RELEASE> -->
 
 <image schemaversion="6.5" name="_PRODUCT_-hyperkube-image">
   <description type="system">
@@ -14,7 +14,7 @@
       derived_from="obsrepositories:/_BASEIMAGE_">
       <containerconfig
         name="_NAMESPACE_/hyperkube"
-        tag="%%SHORT_VERSION%%"
+        tag="v%%SHORT_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <subcommand execute="/bin/sh"/>
       </containerconfig>


### PR DESCRIPTION
- Fixes https://github.com/kubic-project/kubic-init/issues/178
  new name should be hyperkube:vX.Y.Z