### PR TITLE
cilium: Clean up package list

### DIFF
--- a/cilium-image/cilium-image.kiwi.ini
+++ b/cilium-image/cilium-image.kiwi.ini
@@ -38,9 +38,9 @@
     <package name="clang"/>
     <package name="llvm"/>
     <package name="protobuf-c"/>
+    <!-- stdint.h in clang (which is included by BPF programs) requires glibc-32bit headers -->
     <package name="glibc-devel-32bit" arch="x86_64"/>
     <package name="iproute2"/>
-    <package name="gcc"/>
     <package name="which"/>
     <package name="awk"/>
     <package name="cilium"/>


### PR DESCRIPTION
This change removes gcc from the package list (which is not needed,
because only llvm can be used for compiling BPF programs) and adds an
explanation why glibc-devel-32bit is installed.