### PR TITLE
cilium: Add cilium-proxy, labels, history and use additionalflags

### DIFF
--- a/cilium-image/cilium-image.kiwi.ini
+++ b/cilium-image/cilium-image.kiwi.ini
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: _NAMESPACE_/cilium:%%LONG_VERSION%% _NAMESPACE_/cilium:%%LONG_VERSION%%-<RELEASE> -->
-
 <image schemaversion="6.5" name="_PRODUCT_-cilium-image">
   <description type="system">
     <author>SUSE Containers Team</author>
@@ -15,7 +13,8 @@
       <containerconfig
         name="_NAMESPACE_/cilium"
         tag="%%SHORT_VERSION%%"
-        maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
+        maintainer="SUSE Containers Team &lt;containers@suse.com&gt;"
+        additionaltags="%%LONG_VERSION%%">
         <entrypoint execute="/usr/bin/cilium-agent"/>
       </containerconfig>
     </type>

--- a/cilium-image/cilium-image.kiwi.ini
+++ b/cilium-image/cilium-image.kiwi.ini
@@ -42,5 +42,6 @@
   <packages type="image">
     <package name="cilium"/>
     <package name="cilium-cni"/>
+    <package name="cilium-proxy"/>
   </packages>
 </image>

--- a/cilium-image/cilium-image.kiwi.ini
+++ b/cilium-image/cilium-image.kiwi.ini
@@ -16,6 +16,14 @@
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;"
         additionaltags="%%LONG_VERSION%%">
         <entrypoint execute="/usr/bin/cilium-agent"/>
+        <labels>
+          <suse_label_helper:add_prefix prefix="org.opensuse.cilium">
+            <label name="org.opencontainers.image.title" value="Cilium Container"/>
+            <label name="org.opencontainers.image.description" value="Image containing Cilium - software for providing and securing network connectivity and load balancing between containers"/>
+            <label name="org.opencontainers.image.version" value="%%LONG_VERSION%%"/>
+            <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
+          </suse_label_helper:add_prefix>
+        </labels>
       </containerconfig>
     </type>
     <version>4.0.0</version>

--- a/cilium-image/cilium-image.kiwi.ini
+++ b/cilium-image/cilium-image.kiwi.ini
@@ -24,6 +24,7 @@
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
           </suse_label_helper:add_prefix>
         </labels>
+        <history author="Michal Rostecki &lt;mrostecki@opensuse.org&gt;">Cilium Container</history>
       </containerconfig>
     </type>
     <version>4.0.0</version>


### PR DESCRIPTION
This series of commits brings multiple changes to Cilium image:

- `cilium-proxy` package which enables L7 network policies in Cilium
- labels and history for container, according to the guide https://en.opensuse.org/Building_derived_containers
- usage of additionalflags instead to OBS-AddTag