### PR TITLE
cilium: Add cilium-init image

### DIFF
--- a/cilium-init-image/cilium-init-image.kiwi.ini
+++ b/cilium-init-image/cilium-init-image.kiwi.ini
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="6.5" name="_PRODUCT_-cilium-init-image" xmlns:suse_label_helper="com.suse.label_helper">
+  <description type="system">
+    <author>SUSE Containers Team</author>
+    <contact>containers@suse.com</contact>
+    <specification>cilium-init running on an _DISTRO_ container guest</specification>
+  </description>
+  <preferences>
+    <type
+      image="docker"
+      derived_from="obsrepositories:/_BASEIMAGE_">
+      <containerconfig
+        name="_NAMESPACE_/cilium-init"
+        tag="%%SHORT_VERSION%%"
+        maintainer="SUSE Containers Team &lt;containers@suse.com&gt;"
+        additionaltags="%%LONG_VERSION%%">
+        <entrypoint execute="/usr/bin/cilium-init"/>
+        <labels>
+          <suse_label_helper:add_prefix prefix="org.opensuse.cilium-init">
+            <label name="org.opencontainers.image.title" value="cilium-init Container"/>
+            <label name="org.opencontainers.image.description" value="Image containing cilium-init - script for initial pre-deployment operations"/>
+            <label name="org.opencontainers.image.version" value="%%LONG_VERSION%%"/>
+            <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
+          </suse_label_helper:add_prefix>
+        </labels>
+        <history author="Michal Rostecki &lt;mrostecki@opensuse.org&gt;">cilium-init Container</history>
+      </containerconfig>
+    </type>
+    <version>4.0.0</version>
+    <packagemanager>zypper</packagemanager>
+    <rpm-check-signatures>false</rpm-check-signatures>
+    <rpm-force>true</rpm-force>
+    <rpm-excludedocs>true</rpm-excludedocs>
+    <locale>en_US</locale>
+    <keytable>us.map.gz</keytable>
+    <hwclock>utc</hwclock>
+  </preferences>
+  <repository>
+    <source path="obsrepositories:/"/>
+  </repository>
+  <packages type="image">
+    <package name="cilium-init"/>
+  </packages>
+</image>


### PR DESCRIPTION
cilium-init is a script for initial pre-deployment operations which is
supposed to be used for init container for Cilium.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>