### PR TITLE
cilium-operator: Fix package name

### DIFF
--- a/cilium-operator-image/cilium-operator-image.kiwi.ini
+++ b/cilium-operator-image/cilium-operator-image.kiwi.ini
@@ -40,6 +40,6 @@
     <source path="obsrepositories:/"/>
   </repository>
   <packages type="image">
-    <package name="cilium"/>
+    <package name="cilium-operator"/>
   </packages>
 </image>


### PR DESCRIPTION
cilium-operator is a separate package now.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>