### PR TITLE
cilium: Add missing labels

### DIFF
--- a/cilium-etcd-operator-image/cilium-etcd-operator-image.kiwi.ini
+++ b/cilium-etcd-operator-image/cilium-etcd-operator-image.kiwi.ini
@@ -22,6 +22,8 @@
             <label name="org.opencontainers.image.description" value="Image containing cilium-etcd-operator - operator to manage Cilium's etcd cluster"/>
             <label name="org.opencontainers.image.version" value="%%LONG_VERSION%%"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
+            <label name="org.opensuse.reference" value="registry.opensuse.org/kubic/cilium-etcd-operator:%%LONG_VERSION%%"/>
+            <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
           </suse_label_helper:add_prefix>
         </labels>
         <history author="Michal Rostecki &lt;mrostecki@opensuse.org&gt;">cilium-etcd-operator Container</history>

--- a/cilium-image/cilium-image.kiwi.ini
+++ b/cilium-image/cilium-image.kiwi.ini
@@ -22,6 +22,8 @@
             <label name="org.opencontainers.image.description" value="Image containing Cilium - software for providing and securing network connectivity and load balancing between containers"/>
             <label name="org.opencontainers.image.version" value="%%LONG_VERSION%%"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
+            <label name="org.opensuse.reference" value="registry.opensuse.org/kubic/cilium:%%LONG_VERSION%%"/>
+            <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
           </suse_label_helper:add_prefix>
         </labels>
         <history author="Michal Rostecki &lt;mrostecki@opensuse.org&gt;">Cilium Container</history>

--- a/cilium-init-image/cilium-init-image.kiwi.ini
+++ b/cilium-init-image/cilium-init-image.kiwi.ini
@@ -22,6 +22,8 @@
             <label name="org.opencontainers.image.description" value="Image containing cilium-init - script for initial pre-deployment operations"/>
             <label name="org.opencontainers.image.version" value="%%LONG_VERSION%%"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
+            <label name="org.opensuse.reference" value="registry.opensuse.org/kubic/cilium-init:%%LONG_VERSION%%"/>
+            <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
           </suse_label_helper:add_prefix>
         </labels>
         <history author="Michal Rostecki &lt;mrostecki@opensuse.org&gt;">cilium-init Container</history>

--- a/cilium-operator-image/cilium-operator-image.kiwi.ini
+++ b/cilium-operator-image/cilium-operator-image.kiwi.ini
@@ -22,6 +22,8 @@
             <label name="org.opencontainers.image.description" value="Image containing cilium-operator - operator that does garbage collector work for cilium"/>
             <label name="org.opencontainers.image.version" value="%%LONG_VERSION%%"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
+            <label name="org.opensuse.reference" value="registry.opensuse.org/kubic/cilium-operator:%%LONG_VERSION%%"/>
+            <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
           </suse_label_helper:add_prefix>
         </labels>
         <history author="Nirmoy Das &lt;ndas@suse.de&gt;">cilium-operator Container</history>


### PR DESCRIPTION
This change adds the following labels which were missing:

* org.opensuse.reference
* org.openbuildservice.disturl

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>