### PR TITLE
cilium: Several fixes

### DIFF
--- a/cilium-etcd-operator-image/cilium-etcd-operator-image.kiwi.ini
+++ b/cilium-etcd-operator-image/cilium-etcd-operator-image.kiwi.ini
@@ -12,12 +12,12 @@
       derived_from="obsrepositories:/_BASEIMAGE_">
       <containerconfig
         name="_NAMESPACE_/cilium-etcd-operator"
-        tag="%%SHORT_VERSION%%"
+        tag="latest"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;"
-        additionaltags="%%LONG_VERSION%%">
+        additionaltags="%%LONG_VERSION%%,%%LONG_VERSION%%-%RELEASE%">
         <entrypoint execute="/usr/bin/cilium-etcd-operator"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="org.opensuse.cilium-etcd-operator">
+          <suse_label_helper:add_prefix prefix="_LABEL_PREFIX_.cilium-etcd-operator">
             <label name="org.opencontainers.image.title" value="cilium-etcd-operator Container"/>
             <label name="org.opencontainers.image.description" value="Image containing cilium-etcd-operator - operator to manage Cilium's etcd cluster"/>
             <label name="org.opencontainers.image.version" value="%%LONG_VERSION%%"/>

--- a/cilium-image/cilium-image.kiwi.ini
+++ b/cilium-image/cilium-image.kiwi.ini
@@ -12,12 +12,12 @@
       derived_from="obsrepositories:/_BASEIMAGE_">
       <containerconfig
         name="_NAMESPACE_/cilium"
-        tag="%%SHORT_VERSION%%"
+        tag="latest"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;"
-        additionaltags="%%LONG_VERSION%%">
+        additionaltags="%%LONG_VERSION%%,%%LONG_VERSION%%-%RELEASE%">
         <entrypoint execute="/usr/bin/cilium-agent"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="org.opensuse.cilium">
+          <suse_label_helper:add_prefix prefix="_LABEL_PREFIX_.cilium">
             <label name="org.opencontainers.image.title" value="Cilium Container"/>
             <label name="org.opencontainers.image.description" value="Image containing Cilium - software for providing and securing network connectivity and load balancing between containers"/>
             <label name="org.opencontainers.image.version" value="%%LONG_VERSION%%"/>
@@ -52,5 +52,4 @@
     -->
     <package name="libboringssl0"/>
   </packages>
-_EXTRA_BOOTSTRAP_PACKAGES_
 </image>

--- a/cilium-image/kubic-extra-bootstrap-packages
+++ b/cilium-image/kubic-extra-bootstrap-packages
@@ -1,1 +1,0 @@
-openSUSE-release-ftp

--- a/cilium-init-image/cilium-init-image.kiwi.ini
+++ b/cilium-init-image/cilium-init-image.kiwi.ini
@@ -12,12 +12,12 @@
       derived_from="obsrepositories:/_BASEIMAGE_">
       <containerconfig
         name="_NAMESPACE_/cilium-init"
-        tag="%%SHORT_VERSION%%"
+        tag="latest"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;"
-        additionaltags="%%LONG_VERSION%%">
+        additionaltags="%%LONG_VERSION%%,%%LONG_VERSION%%-%RELEASE%">
         <entrypoint execute="/usr/bin/cilium-init"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="org.opensuse.cilium-init">
+          <suse_label_helper:add_prefix prefix="_LABEL_PREFIX_.cilium-init">
             <label name="org.opencontainers.image.title" value="cilium-init Container"/>
             <label name="org.opencontainers.image.description" value="Image containing cilium-init - script for initial pre-deployment operations"/>
             <label name="org.opencontainers.image.version" value="%%LONG_VERSION%%"/>

--- a/cilium-operator-image/cilium-operator-image.kiwi.ini
+++ b/cilium-operator-image/cilium-operator-image.kiwi.ini
@@ -12,12 +12,12 @@
       derived_from="obsrepositories:/_BASEIMAGE_">
       <containerconfig
         name="_NAMESPACE_/cilium-operator"
-        tag="%%SHORT_VERSION%%"
+        tag="latest"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;"
-        additionaltags="%%LONG_VERSION%%">
+        additionaltags="%%LONG_VERSION%%,%%LONG_VERSION%%-%RELEASE%">
         <entrypoint execute="/usr/bin/cilium-operator"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="org.opensuse.cilium-operator">
+          <suse_label_helper:add_prefix prefix="_LABEL_PREFIX_.cilium-operator">
             <label name="org.opencontainers.image.title" value="cilium-operator Container"/>
             <label name="org.opencontainers.image.description" value="Image containing cilium-operator - operator that does garbage collector work for cilium"/>
             <label name="org.opencontainers.image.version" value="%%LONG_VERSION%%"/>


### PR DESCRIPTION
This change contains the following fixes for the Cilium image:

- Using `latest` as the tag and version strings as additional tags.
- Using _LABEL_PREFIX_ as the label prefix, which means consuming it
  from pre_checkin.sh script.
- Remove extra bootsrap packages.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>