### PR TITLE
cilium: use the same ExclusiveArch as cilium.spec does

### DIFF
--- a/cilium-image/cilium-image.kiwi.ini
+++ b/cilium-image/cilium-image.kiwi.ini
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- OBS-ExclusiveArch: aarch64 x86_64 -->
 
 <image schemaversion="6.5" name="_PRODUCT_-cilium-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">

--- a/cilium-init-image/cilium-init-image.kiwi.ini
+++ b/cilium-init-image/cilium-init-image.kiwi.ini
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- OBS-ExclusiveArch: aarch64 x86_64 -->
 
 <image schemaversion="6.5" name="_PRODUCT_-cilium-init-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">

--- a/cilium-operator-image/cilium-operator-image.kiwi.ini
+++ b/cilium-operator-image/cilium-operator-image.kiwi.ini
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- OBS-ExclusiveArch: aarch64 x86_64 -->
 
 <image schemaversion="6.5" name="_PRODUCT_-cilium-operator-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">


### PR DESCRIPTION
Without cilium building there is no point in attempting to build the image for it