### PR TITLE
Add labels, prepare to use busybox base image

### DIFF
--- a/coredns-image/coredns-image.kiwi.ini
+++ b/coredns-image/coredns-image.kiwi.ini
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: _NAMESPACE_/coredns:%%LONG_VERSION%% _NAMESPACE_/coredns:%%LONG_VERSION%%-<RELEASE> -->
+<!-- OBS-ExcludeArch: i586 s390 -->
 
-<image schemaversion="6.5" name="_PRODUCT_-coredns-image">
+<image schemaversion="6.5" name="_PRODUCT_-coredns-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
     <author>SUSE Containers Team</author>
     <contact>containers@suse.com</contact>
@@ -11,10 +11,11 @@
   <preferences>
     <type
       image="docker"
-      derived_from="obsrepositories:/_BASEIMAGE_">
+      derived_from="obsrepositories:/_BASEIMAGE_SMALL_">
       <containerconfig
         name="_NAMESPACE_/coredns"
-        tag="%%SHORT_VERSION%%"
+        tag="latest"
+        additionaltags="%%LONG_VERSION%%,%%LONG_VERSION%%-%RELEASE%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <expose>
           <port number="53/tcp"/>
@@ -22,12 +23,22 @@
         </expose>
         <entrypoint execute="/usr/sbin/coredns"/>
         <subcommand clear="true"/>
+	<labels>
+          <suse_label_helper:add_prefix prefix="_LABEL_PREFIX_.coredns">
+            <label name="org.opencontainers.image.title" value="_DISTRO_ coredns container"/>
+            <label name="org.opencontainers.image.description" value="Image containing coredns for _DISTRO_."/>
+            <label name="org.opencontainers.image.version" value="%%LONG_VERSION%%-%RELEASE%"/>
+            <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
+            <label name="org.opensuse.reference" value="registry.opensuse.org/opensuse/coredns:%%LONG_VERSION%%-%RELEASE%"/>
+            <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
+          </suse_label_helper:add_prefix>
+        </labels>
+        <history author="SUSE Containers Team &lt;containers@suse.com&gt;">_DISTRO_ coredns container</history>
       </containerconfig>
     </type>
-    <version>4.0.1</version>
+    <version>5.0.0</version>
     <packagemanager>zypper</packagemanager>
     <rpm-check-signatures>false</rpm-check-signatures>
-    <rpm-force>true</rpm-force>
     <rpm-excludedocs>true</rpm-excludedocs>
     <locale>en_US</locale>
     <keytable>us.map.gz</keytable>
@@ -36,7 +47,7 @@
   <repository>
     <source path="obsrepositories:/"/>
   </repository>
-  <packages type="image">
+  <packages type="bootstrap">
     <package name="coredns"/>
   </packages>
 </image>


### PR DESCRIPTION
Adjust the image to the current policies, so that we can release it in the kubic registry namespace.